### PR TITLE
Removed redundant symlink and fixed double header issue by hiding the one from the original markdown files.

### DIFF
--- a/website/CONTRIBUTING.md
+++ b/website/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-../CONTRIBUTING.md

--- a/website/docs/04_community/code_of_conduct.mdx
+++ b/website/docs/04_community/code_of_conduct.mdx
@@ -1,5 +1,7 @@
 import CodeOfConduct from '../../../CODE_OF_CONDUCT.md';
 
-# Code of Conduct
+# Contributor Covenant Code of Conduct
 
+<div class="hiddenh1s">
 <CodeOfConduct/>
+</div>

--- a/website/docs/04_community/contributing.mdx
+++ b/website/docs/04_community/contributing.mdx
@@ -1,5 +1,7 @@
 import ContributingGuide from '../../../CONTRIBUTING.md';
 
-# Introduction
+# Contributing Guide
 
+<div class="hiddenh1s">
 <ContributingGuide />
+</div>

--- a/website/docs/04_community/index.md
+++ b/website/docs/04_community/index.md
@@ -1,0 +1,10 @@
+# Community
+
+Community contributions are essential to the development and refinement of eLLMental. You can become a part of the eLLMental community in the following ways:
+
+1. Join the conversation in our [Discord server](https://discord.gg/34cBbvjjAx).
+2. Send us suggestions, questions, or feature requests by creating a [New Issue](https://github.com/theam/ellmental/issues/new).
+3. Look at the [Open Issues](https://github.com/theam/ellmental/issues), choose one that interests you, and start contributing.
+4. Spread the word about eLLMental!
+
+Find detailed instructions and guidelines in the [Contributing Guide](contributing), and make sure to read our [Code of Conduct](code_of_conduct) before you start contributing.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -25,14 +25,18 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Contributing',
+      label: 'Community',
       link: {
         type: 'doc',
-        id: 'contributing/index'
+        id: 'community/index'
       },
       items: [
-        'contributing/index',
-        'contributing/code_of_conduct',
+        'community/contributing',
+        {
+          type: 'doc',
+          id: 'community/code_of_conduct',
+          label: 'Code of Conduct'
+        }
       ]
     },
     {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -38,3 +38,7 @@
 .navbar__logo {
   height: 1.5rem;
 }
+
+.hiddenh1s > h1 {
+  display: none;
+}


### PR DESCRIPTION
Now the menu looks like this:

![Screenshot 2023-07-19 at 16 58 42](https://github.com/theam/eLLMental/assets/175096/8208b4e6-f336-47c9-8483-ce1005b9707f)

And the guides only show the title rendered by 
![Screenshot 2023-07-19 at 17 00 01](https://github.com/theam/eLLMental/assets/175096/ba8afa47-4208-4e69-92ad-06ee9d0c6fc2)
docusaurus:

 