### PR TITLE
Add JvmOverloads annotation to enhance JVM compatibility

### DIFF
--- a/examples/semanticsearchservicedemo/src/main/kotlin/com/theagilemonkeys/ellmental/semanticsearchservicedemo/Main.kt
+++ b/examples/semanticsearchservicedemo/src/main/kotlin/com/theagilemonkeys/ellmental/semanticsearchservicedemo/Main.kt
@@ -1,10 +1,10 @@
 package com.theagilemonkeys.ellmental.semanticsearchservicedemo
 
-import com.aallam.openai.client.OpenAI
 import com.theagilemonkeys.ellmental.core.api.API
 import com.theagilemonkeys.ellmental.core.api.apiDefinition
 import com.theagilemonkeys.ellmental.core.api.runHttp
 import com.theagilemonkeys.ellmental.embeddingsmodel.openai.OpenAIEmbeddingsModel
+import com.theagilemonkeys.ellmental.embeddingsmodel.openai.openAIClient
 import com.theagilemonkeys.ellmental.semanticsearch.SearchInput
 import com.theagilemonkeys.ellmental.semanticsearch.SemanticSearch
 import com.theagilemonkeys.ellmental.vectorstore.pinecone.PineconeVectorStore
@@ -49,7 +49,7 @@ fun buildApi(): API<SemanticSearch> {
         it
     }
 
-    with(OpenAI(token = openaiToken)) {
+    with(openAIClient(apiKey = openaiToken)) {
         with(OpenAIEmbeddingsModel()) {
             with(PineconeVectorStore(apiKey = pineconeToken, url = pineconeUrl)) {
                 with(SemanticSearch()) {

--- a/examples/semanticsearchservicedemo/src/main/kotlin/com/theagilemonkeys/ellmental/semanticsearchservicedemo/Main.kt
+++ b/examples/semanticsearchservicedemo/src/main/kotlin/com/theagilemonkeys/ellmental/semanticsearchservicedemo/Main.kt
@@ -3,8 +3,8 @@ package com.theagilemonkeys.ellmental.semanticsearchservicedemo
 import com.theagilemonkeys.ellmental.core.api.API
 import com.theagilemonkeys.ellmental.core.api.apiDefinition
 import com.theagilemonkeys.ellmental.core.api.runHttp
+import com.theagilemonkeys.ellmental.embeddingsmodel.openai.OpenAIClient
 import com.theagilemonkeys.ellmental.embeddingsmodel.openai.OpenAIEmbeddingsModel
-import com.theagilemonkeys.ellmental.embeddingsmodel.openai.openAIClient
 import com.theagilemonkeys.ellmental.semanticsearch.SearchInput
 import com.theagilemonkeys.ellmental.semanticsearch.SemanticSearch
 import com.theagilemonkeys.ellmental.vectorstore.pinecone.PineconeVectorStore
@@ -49,7 +49,7 @@ fun buildApi(): API<SemanticSearch> {
         it
     }
 
-    with(openAIClient(apiKey = openaiToken)) {
+    with(OpenAIClient(apiKey = openaiToken)) {
         with(OpenAIEmbeddingsModel()) {
             with(PineconeVectorStore(apiKey = pineconeToken, url = pineconeUrl)) {
                 with(SemanticSearch()) {

--- a/modules/embeddingsmodel/src/main/kotlin/com/theagilemonkeys/ellmental/embeddingsmodel/openai/OpenAIClient.kt
+++ b/modules/embeddingsmodel/src/main/kotlin/com/theagilemonkeys/ellmental/embeddingsmodel/openai/OpenAIClient.kt
@@ -1,0 +1,33 @@
+package com.theagilemonkeys.ellmental.embeddingsmodel.openai
+
+import com.aallam.openai.api.http.Timeout
+import com.aallam.openai.client.*
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * # OpenAI client generator
+ *
+ * Wrapper to create an [OpenAI] client with default parameters for JVM compatibility
+ *
+ */
+@JvmOverloads fun openAIClient(
+    apiKey: String,
+    logging: LoggingConfig = LoggingConfig(),
+    timeout: Timeout = Timeout(socket = 30.seconds),
+    organization: String? = null,
+    headers: Map<String, String> = emptyMap(),
+    host: OpenAIHost = OpenAIHost.OpenAI,
+    proxy: ProxyConfig? = null,
+    retry: RetryStrategy = RetryStrategy(),
+): OpenAI {
+    return OpenAI(
+        token = apiKey,
+        logging = logging,
+        timeout = timeout,
+        organization = organization,
+        headers = headers,
+        host = host,
+        proxy = proxy,
+        retry = retry
+    )
+}

--- a/modules/embeddingsmodel/src/main/kotlin/com/theagilemonkeys/ellmental/embeddingsmodel/openai/OpenAIClient.kt
+++ b/modules/embeddingsmodel/src/main/kotlin/com/theagilemonkeys/ellmental/embeddingsmodel/openai/OpenAIClient.kt
@@ -10,7 +10,8 @@ import kotlin.time.Duration.Companion.seconds
  * Wrapper to create an [OpenAI] client with default parameters for JVM compatibility
  *
  */
-@JvmOverloads fun openAIClient(
+@JvmOverloads
+fun OpenAIClient(
     apiKey: String,
     logging: LoggingConfig = LoggingConfig(),
     timeout: Timeout = Timeout(socket = 30.seconds),

--- a/modules/vectorstore/src/main/kotlin/com/theagilemonkeys/ellmental/vectorstore/pinecone/PineconeVectorStore.kt
+++ b/modules/vectorstore/src/main/kotlin/com/theagilemonkeys/ellmental/vectorstore/pinecone/PineconeVectorStore.kt
@@ -21,7 +21,7 @@ import org.http4k.core.Request
  * @param apiKey The API key to use to authenticate with the Pinecone API.
  * @param url The URL of the Pinecone API.
  */
-class PineconeVectorStore(
+class PineconeVectorStore @JvmOverloads constructor(
     private val apiKey: String,
     private val url: String,
     private val client: HttpHandler = OkHttp(),


### PR DESCRIPTION
This PR adds `@JVMOverloads` to those public interfaces with default parameters that didn't have it to enhance compatibility with JVM languages and avoid them having to enter all the default parameters, and therefore, constructing and importing libraries that might not need