### PR TITLE
Adding import to example code

### DIFF
--- a/website/docs/02_getting_started.md
+++ b/website/docs/02_getting_started.md
@@ -132,6 +132,7 @@ later.
 
 ```kotlin
 import com.theagilemonkeys.ellmental.semanticsearch.SemanticSearch
+import com.theagilemonkeys.ellmental.semanticsearch.SearchInput
 
 suspend fun learn(semanticSearch: SemanticSearch, note: Note) {
     semanticSearch.learn(SearchInput(listOf(note.content)))


### PR DESCRIPTION
The code example doesn't import the class SearchInput, which is used by the function.