### PR TITLE
Create JVM compatible versions of suspend functions. Add annotations to replace names in JVM compiled libraries.

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+ellmental

--- a/modules/semanticsearch/build.gradle.kts
+++ b/modules/semanticsearch/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
     implementation(projects.core)
     implementation(projects.modules.embeddingsmodel)
     implementation(projects.modules.vectorstore)
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.3")
 }

--- a/modules/semanticsearch/src/main/kotlin/com/theagilemonkeys/ellmental/semanticsearch/SemanticSearch.kt
+++ b/modules/semanticsearch/src/main/kotlin/com/theagilemonkeys/ellmental/semanticsearch/SemanticSearch.kt
@@ -79,7 +79,7 @@ class SemanticSearch {
     @OptIn(DelicateCoroutinesApi::class)
     @JvmName("search")
     fun searchCompletableFuture(text: String, itemsLimit: Int) =
-        GlobalScope.future { search(text) }
+        GlobalScope.future { search(text, itemsLimit) }
 }
 
 @Serializable

--- a/modules/semanticsearch/src/main/kotlin/com/theagilemonkeys/ellmental/semanticsearch/SemanticSearch.kt
+++ b/modules/semanticsearch/src/main/kotlin/com/theagilemonkeys/ellmental/semanticsearch/SemanticSearch.kt
@@ -4,6 +4,9 @@ import com.theagilemonkeys.ellmental.core.schema.SemanticEntry
 import com.theagilemonkeys.ellmental.core.schema.SemanticEntryMatch
 import com.theagilemonkeys.ellmental.embeddingsmodel.EmbeddingsModel
 import com.theagilemonkeys.ellmental.vectorstore.VectorStore
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.future
 import kotlinx.serialization.Serializable
 
 context(EmbeddingsModel<Any>, VectorStore)
@@ -22,6 +25,7 @@ class SemanticSearch {
      *
      * @param input A list of texts to be learned.
      */
+    @JvmName("learn\$Kotlin")
     suspend fun learn(input: LearnInput) =
         input.texts.forEach { text ->
             check(text.isNotBlank()) { "Text cannot be blank" }
@@ -29,6 +33,21 @@ class SemanticSearch {
             val semanticEntry = SemanticEntry(content = text, embedding = embedding)
             upsert(semanticEntry)
         }
+
+    /**
+     *
+     * "Learns" a list of texts to make them available in future semantic searches. It uses the
+     * [EmbeddingsModel] to calculate text embeddings for each piece of text. Then it uses the
+     * [VectorStore] to persist them.
+     *
+     * @param input A list of texts to be learned.
+     *
+     * (JVM compatible version)
+     */
+    @OptIn(DelicateCoroutinesApi::class)
+    @JvmName("learn")
+    suspend fun learnCompletableFuture(input: LearnInput) =
+        GlobalScope.future { learn(input) }
 
     /**
      * Performs a semantic search operation using the provided text as reference. It will look for
@@ -39,12 +58,28 @@ class SemanticSearch {
      * @param itemsLimit The maximum number of results to return.
      * @return A list of semantically similar texts ranked by semantic distance (the closest first).
      */
+    @JvmName("search\$Kotlin")
     suspend fun search(text: String, itemsLimit: Int): SearchOutput {
         check(text.isNotBlank()) { "Text cannot be blank" }
         val embedding = embed(text)
         val semanticEntry = SemanticEntry(content = text, embedding = embedding)
         return SearchOutput(query(semanticEntry, itemsLimit).entries)
     }
+
+    /**
+     * Performs a semantic search operation using the provided text as reference. It will look for
+     * texts stored in the [VectorStore] that are "semantically close" to the provided one and return
+     * a ranked list of results.
+     *
+     * @param text The text to be used as reference for semantic search.
+     * @return A list of semantically similar texts ranked by semantic distance (the closest first).
+     *
+     * (JVM compatible version)
+     */
+    @OptIn(DelicateCoroutinesApi::class)
+    @JvmName("search")
+    suspend fun searchCompletableFuture(text: String, itemsLimit: Int) =
+        GlobalScope.future { search(text) }
 }
 
 @Serializable

--- a/modules/semanticsearch/src/main/kotlin/com/theagilemonkeys/ellmental/semanticsearch/SemanticSearch.kt
+++ b/modules/semanticsearch/src/main/kotlin/com/theagilemonkeys/ellmental/semanticsearch/SemanticSearch.kt
@@ -46,7 +46,7 @@ class SemanticSearch {
      */
     @OptIn(DelicateCoroutinesApi::class)
     @JvmName("learn")
-    suspend fun learnCompletableFuture(input: LearnInput) =
+    fun learnCompletableFuture(input: LearnInput) =
         GlobalScope.future { learn(input) }
 
     /**
@@ -78,7 +78,7 @@ class SemanticSearch {
      */
     @OptIn(DelicateCoroutinesApi::class)
     @JvmName("search")
-    suspend fun searchCompletableFuture(text: String, itemsLimit: Int) =
+    fun searchCompletableFuture(text: String, itemsLimit: Int) =
         GlobalScope.future { search(text) }
 }
 


### PR DESCRIPTION
This PR temporarily solves #47.

It includes fixed methods of `SemanticSearch` class that are compatible with JVM since it generates `CompletableFuture` from the `GlobalScope`.

This mechanism does two different things:
1. It generates two types of functions: one using coroutines, and another one using Java virtual threads with `CompletableFututre`.
2. It changes the names in JVM compiled libraries to make the default solution the one compatible with Java.

If someone generates new `suspend` functions that are callable in the API, they would need to follow the same process.

A metaprogramming solution like the generation of an annotation processor to generate code on compile time is needed to solve this easily without code repetition. For example, creating a `@JvmCompletableFuture` annotation and a code processor.